### PR TITLE
Ignore field configuration for count query

### DIFF
--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -1585,7 +1585,6 @@ public class Query {
     }
 
     public Integer countQuery() {
-        count('');
         isCountQuery = true;
         String queryString = formQueryString();
         isCountQuery = false;
@@ -1622,7 +1621,7 @@ public class Query {
     private ParentFieldSetting parentFieldSetting;
 
     private List<String> conditions = new List<String>();
-    private static final Integer maxArgSize = 20;
+    private static final Integer maxArgSize = 40;
     private Integer finalConditionArgsIdx = 0;
     private List<Object> conditionArgs = new List<Object>();
     private List<Object> finalConditionArgs = new List<Object>();
@@ -1646,6 +1645,26 @@ public class Query {
     private Object conditionArgs17;
     private Object conditionArgs18;
     private Object conditionArgs19;
+    private Object conditionArgs20;
+    private Object conditionArgs21;
+    private Object conditionArgs22;
+    private Object conditionArgs23;
+    private Object conditionArgs24;
+    private Object conditionArgs25;
+    private Object conditionArgs26;
+    private Object conditionArgs27;
+    private Object conditionArgs28;
+    private Object conditionArgs29;
+    private Object conditionArgs30;
+    private Object conditionArgs31;
+    private Object conditionArgs32;
+    private Object conditionArgs33;
+    private Object conditionArgs34;
+    private Object conditionArgs35;
+    private Object conditionArgs36;
+    private Object conditionArgs37;
+    private Object conditionArgs38;
+    private Object conditionArgs39;
 
     private String conditionOperator = 'AND';
     private String optionalClause = '';
@@ -2019,6 +2038,46 @@ public class Query {
             conditionArgs18 = arg;
         } else if (idx == 19) {
             conditionArgs19 = arg;
+        } else if (idx == 20) {
+            conditionArgs20 = arg;
+        } else if (idx == 21) {
+            conditionArgs21 = arg;            
+        } else if (idx == 22) {
+            conditionArgs22 = arg;
+        } else if (idx == 23) {
+            conditionArgs23 = arg;
+        } else if (idx == 24) {
+            conditionArgs24 = arg;
+        } else if (idx == 25) {
+            conditionArgs25 = arg;
+        } else if (idx == 26) {
+            conditionArgs26 = arg;
+        } else if (idx == 27) {
+            conditionArgs27 = arg;
+        } else if (idx == 28) {
+            conditionArgs28 = arg;
+        } else if (idx == 29) {
+            conditionArgs29 = arg;
+        } else if (idx == 30) {
+            conditionArgs30 = arg;
+        } else if (idx == 31) {
+            conditionArgs31 = arg;
+        } else if (idx == 32) {
+            conditionArgs32 = arg;
+        } else if (idx == 33) {
+            conditionArgs33 = arg;
+        } else if (idx == 34) {
+            conditionArgs34 = arg;
+        } else if (idx == 35) {
+            conditionArgs35 = arg;
+        } else if (idx == 36) {
+            conditionArgs36 = arg;
+        } else if (idx == 37) {
+            conditionArgs37 = arg;
+        } else if (idx == 38) {
+            conditionArgs38 = arg;
+        } else if (idx == 39) {
+            conditionArgs39 = arg;
         }
     }
 

--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -1621,7 +1621,8 @@ public class Query {
     private ParentFieldSetting parentFieldSetting;
 
     private List<String> conditions = new List<String>();
-    private static final Integer maxArgSize = 40;
+    @testVisible
+    private static final Integer maxArgSize = 60;
     private Integer finalConditionArgsIdx = 0;
     private List<Object> conditionArgs = new List<Object>();
     private List<Object> finalConditionArgs = new List<Object>();
@@ -1665,6 +1666,26 @@ public class Query {
     private Object conditionArgs37;
     private Object conditionArgs38;
     private Object conditionArgs39;
+    private Object conditionArgs40;
+    private Object conditionArgs41;
+    private Object conditionArgs42;
+    private Object conditionArgs43;
+    private Object conditionArgs44;
+    private Object conditionArgs45;
+    private Object conditionArgs46;
+    private Object conditionArgs47;
+    private Object conditionArgs48;
+    private Object conditionArgs49;
+    private Object conditionArgs50;
+    private Object conditionArgs51;
+    private Object conditionArgs52;
+    private Object conditionArgs53;
+    private Object conditionArgs54;
+    private Object conditionArgs55;
+    private Object conditionArgs56;
+    private Object conditionArgs57;
+    private Object conditionArgs58;
+    private Object conditionArgs59;
 
     private String conditionOperator = 'AND';
     private String optionalClause = '';
@@ -2078,6 +2099,46 @@ public class Query {
             conditionArgs38 = arg;
         } else if (idx == 39) {
             conditionArgs39 = arg;
+        } else if (idx == 40) {
+            conditionArgs40 = arg;
+        } else if (idx == 41) {
+            conditionArgs41 = arg;            
+        } else if (idx == 42) {
+            conditionArgs42 = arg;
+        } else if (idx == 43) {
+            conditionArgs43 = arg;
+        } else if (idx == 44) {
+            conditionArgs44 = arg;
+        } else if (idx == 45) {
+            conditionArgs45 = arg;
+        } else if (idx == 46) {
+            conditionArgs46 = arg;
+        } else if (idx == 47) {
+            conditionArgs47 = arg;
+        } else if (idx == 48) {
+            conditionArgs48 = arg;
+        } else if (idx == 49) {
+            conditionArgs49 = arg;
+        } else if (idx == 50) {
+            conditionArgs50 = arg;
+        } else if (idx == 51) {
+            conditionArgs51 = arg;
+        } else if (idx == 52) {
+            conditionArgs52 = arg;
+        } else if (idx == 53) {
+            conditionArgs53 = arg;
+        } else if (idx == 54) {
+            conditionArgs54 = arg;
+        } else if (idx == 55) {
+            conditionArgs55 = arg;
+        } else if (idx == 56) {
+            conditionArgs56 = arg;
+        } else if (idx == 57) {
+            conditionArgs57 = arg;
+        } else if (idx == 58) {
+            conditionArgs58 = arg;
+        } else if (idx == 59) {
+            conditionArgs59 = arg;
         }
     }
 

--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -1585,9 +1585,11 @@ public class Query {
     }
 
     public Integer countQuery() {
-        count('');
+        this.isCountQuery = true;
         String queryString = formQueryString();
-        return Database.countQuery(queryString);
+        Integer count = Database.countQuery(queryString);
+        this.isCountQuery;
+        return count;
     }
 
     public List<Id> toIdList() {
@@ -1741,6 +1743,7 @@ public class Query {
     private String objectName;
     private Schema.SObjectType objectType;
     private Map<String, Schema.SObjectType> childRelationships;
+    private Boolean isCountQuery = false;
 
     private Query addAllFields() {
         // Get all the fields
@@ -2094,6 +2097,10 @@ public class Query {
 
     private String formFieldString() {
         String fieldString = '';
+
+        if (isCountQuery) {
+            return 'COUNT()';
+        }
 
         for (String parentName : parentReferences) {
             addParentFields(parentName);

--- a/src/classes/Query.cls
+++ b/src/classes/Query.cls
@@ -1585,11 +1585,11 @@ public class Query {
     }
 
     public Integer countQuery() {
-        this.isCountQuery = true;
+        count('');
+        isCountQuery = true;
         String queryString = formQueryString();
-        Integer count = Database.countQuery(queryString);
-        this.isCountQuery;
-        return count;
+        isCountQuery = false;
+        return Database.countQuery(queryString);
     }
 
     public List<Id> toIdList() {
@@ -2041,12 +2041,16 @@ public class Query {
         finalConditionArgsIdx = 0;
 
         String query = 'SELECT ';
+        
+        if (this.isCountQuery) {
+            query += 'COUNT()';
+        } else {
+            query += formFieldString();
 
-        query += formFieldString();
-
-        if (!functionFieldList.isEmpty()) {
-            query += ' ' + formAggregateString();
-        }
+            if (!functionFieldList.isEmpty()) {
+                query += ' ' + formAggregateString();
+            }
+        } 
 
         query += ' FROM ' + objectName;
 
@@ -2097,10 +2101,6 @@ public class Query {
 
     private String formFieldString() {
         String fieldString = '';
-
-        if (isCountQuery) {
-            return 'COUNT()';
-        }
 
         for (String parentName : parentReferences) {
             addParentFields(parentName);

--- a/src/classes/Query.cls-meta.xml
+++ b/src/classes/Query.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/QueryTest.cls
+++ b/src/classes/QueryTest.cls
@@ -1119,6 +1119,7 @@ public class QueryTest {
 
         System.assertEquals(4, new Query('Account').countQuery());
         System.assertEquals(2, new Query('Account').addConditionEq('Rating', '1').countQuery());
+        System.assertEquals(4, new Query('Account').selectAllFields('Account').addConditionEq('Rating', '1').countQuery());
     }
 
     @isTest

--- a/src/classes/QueryTest.cls
+++ b/src/classes/QueryTest.cls
@@ -1119,7 +1119,7 @@ public class QueryTest {
 
         System.assertEquals(4, new Query('Account').countQuery());
         System.assertEquals(2, new Query('Account').addConditionEq('Rating', '1').countQuery());
-        System.assertEquals(4, new Query('Account').selectAllFields('Account').addConditionEq('Rating', '1').countQuery());
+        System.assertEquals(2, new Query('Account').selectAllFields('Account').addConditionEq('Rating', '1').countQuery());
     }
 
     @isTest

--- a/src/classes/QueryTest.cls
+++ b/src/classes/QueryTest.cls
@@ -1351,6 +1351,35 @@ public class QueryTest {
         System.assert(c != null);
     }
 
+    @isTest
+    static void largeWhereClauseTest() {
+        Integer maxWhereConditions = Query.maxArgSize;
+
+        Query query = new Query('Account');
+        for (Integer i = 0; i < maxWhereConditions; i++) {
+            query.addConditionEq('Name', 'Name' + i);
+        }
+
+        Exception excptn;
+        
+        try {
+            query.run();
+        } catch (Exception ex) {
+            excptn = ex;
+        }
+
+		Assert.areEqual(null, excptn);        
+
+        Test.startTest();
+            try {
+                query.addConditionEq('Name', 'Name' + maxWhereConditions);
+                query.run();
+            } catch (Exception qex) {
+                Assert.isNotNull(qex);
+                //Assert.areEqual('The number of arguments exceeds the limit', qex.getMessage());
+            } 
+        Test.stopTest();
+    }
     static void createData() {
         Account acc = new Account();
         acc.Name = 'ABC Ltd';

--- a/src/classes/QueryTest.cls-meta.xml
+++ b/src/classes/QueryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
@HenryRLee  the pull request allows to run COUNT() query even if list of fields is already set. This can be beneficial in some cases when you need to use the same Query object to make both normal query and count query.

Could you please review my pull request.